### PR TITLE
Add save_images toggle to PyMuPDF tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ PyMuPDF Plugin is a high-performance tool that allows you to extract, analyze, a
 - Maintain page structure with clear page separations
 - Return both human-readable text and structured JSON data
 - Detailed metadata including page numbers and file information
+- Optional image extraction with a `save_images` toggle to save or skip embedded images
 
 ## Installation
 
@@ -35,7 +36,8 @@ To install the PyMuPDF Plugin:
 Once installed, the plugin can be accessed through the Dify interface:
 
 1. Upload one or more PDF files using the file selector
-2. The plugin will process each file and return:
+2. Choose whether to keep `save_images` enabled (default) to extract embedded images to temporary files referenced in the Markdown output
+3. The plugin will process each file and return:
    - Text content extracted from all pages
    - Structured JSON data with page-by-page content and metadata
    - Raw text content as a downloadable blob

--- a/tools/pymupdf.py
+++ b/tools/pymupdf.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Generator
+from pathlib import Path
 from typing import Any
 import io
 
@@ -13,6 +14,7 @@ logger = logging.getLogger(__name__)
 
 class ToolParameters(BaseModel):
     files: list[File]
+    save_images: bool = True
 
 
 class PymupdfTool(Tool):
@@ -28,7 +30,13 @@ class PymupdfTool(Tool):
             return
             
         params = ToolParameters(**tool_parameters)
+
+        if not isinstance(params.save_images, bool):
+            yield self.create_text_message("Invalid parameter: 'save_images' must be a boolean.")
+            return
+
         files = params.files
+        save_images = params.save_images
 
         try:
             # Try both import methods to ensure compatibility
@@ -42,34 +50,76 @@ class PymupdfTool(Tool):
             for file in files:
                 try:
                     logger.info(f"Processing file: {file.filename}")
-                    
+
                     # Process PDF file
                     file_bytes = io.BytesIO(file.blob)
                     doc = fitz_module.open(stream=file_bytes, filetype="pdf")
-                    
+
                     page_count = doc.page_count
                     documents = []
-                    
+                    markdown_parts: list[str] = [f"# {file.filename}", f"Total pages: {page_count}"]
+                    image_output_dir = Path("/tmp/pymupdf-images")
+                    if save_images:
+                        image_output_dir.mkdir(parents=True, exist_ok=True)
+
                     for page_num in range(page_count):
                         page = doc.load_page(page_num)
                         text = page.get_text()
-                        documents.append({
+                        page_record: dict[str, Any] = {
                             "text": text,
                             "metadata": {
                                 "page": page_num + 1,
                                 "file_name": file.filename
                             }
-                        })
-                    
+                        }
+
+                        markdown_parts.append(f"\n## Page {page_num + 1}")
+                        markdown_parts.append(text or "_No text content extracted._")
+
+                        if save_images:
+                            images = page.get_images(full=True)
+                            extracted_images = []
+                            for image_index, image in enumerate(images, start=1):
+                                xref = image[0]
+                                base_image = doc.extract_image(xref)
+                                image_bytes = base_image.get("image")
+                                if image_bytes is None:
+                                    continue
+
+                                image_ext = base_image.get("ext", "png")
+                                safe_stem = Path(file.filename).stem.replace(" ", "_")
+                                image_filename = f"{safe_stem}_page{page_num + 1}_image{image_index}.{image_ext}"
+                                image_path = image_output_dir / image_filename
+
+                                with open(image_path, "wb") as image_file:
+                                    image_file.write(image_bytes)
+
+                                extracted_images.append({
+                                    "page": page_num + 1,
+                                    "image_index": image_index,
+                                    "path": str(image_path)
+                                })
+                                markdown_parts.append(
+                                    f"![Page {page_num + 1} Image {image_index}]({image_path})"
+                                )
+
+                            if extracted_images:
+                                page_record["images"] = extracted_images
+                        else:
+                            if page.get_images(full=True):
+                                markdown_parts.append("_Images detected on this page were skipped (save_images=false)._")
+
+                        documents.append(page_record)
+
                     # Close the document to free resources
                     doc.close()
-                    
+
                     # Join all extracted text with page separators
                     texts = "\n\n---PAGE BREAK---\n\n".join([doc["text"] for doc in documents])
-                    
+
                     # Yield text message for human readability
-                    yield self.create_text_message(texts)
-                    
+                    yield self.create_text_message("\n\n".join(markdown_parts))
+
                     # Yield structured JSON data
                     yield self.create_json_message({file.filename: documents})
                     

--- a/tools/pymupdf.yaml
+++ b/tools/pymupdf.yaml
@@ -14,7 +14,7 @@ description:
 parameters:
   - name: files
     type: files
-    required: false 
+    required: false
     label:
       en_US: Files
       zh_Hans: 文件
@@ -23,6 +23,19 @@ parameters:
       en_US: Upload PDF files for processing
       zh_Hans: 上传PDF文件进行处理
       pt_BR: Carregar arquivos PDF para processamento
+    form: llm
+  - name: save_images
+    type: boolean
+    required: false
+    default: true
+    label:
+      en_US: Save images
+      zh_Hans: 保存图像
+      pt_BR: Salvar imagens
+    human_description:
+      en_US: Extract and save embedded images to temporary files (disable to skip image extraction)
+      zh_Hans: 提取并保存嵌入的图像到临时文件（禁用以跳过图像提取）
+      pt_BR: Extrair e salvar imagens incorporadas em arquivos temporários (desative para pular a extração de imagens)
     form: llm
 extra:
   python:


### PR DESCRIPTION
## Summary
- add an optional save_images flag to control embedded image extraction and Markdown output
- validate the new flag, skip file writes when disabled, and surface extracted images with metadata
- document the new option in the tool schema and README

## Testing
- python -m compileall tools

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69227e7e32f083218fdfaca3a8a46dac)